### PR TITLE
Remove inspection of function props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,9 @@ const unexpectedEnzyme = {
                   .text('}');
               }
               break;
+            case 'function':
+              startTag.text('={...}');
+              break;
             default:
               startTag
                 .text('={')

--- a/test/inspect.spec.js
+++ b/test/inspect.spec.js
@@ -52,6 +52,18 @@ describe('inspect', () => {
           '<div>foo<div />bar<div />baz</div>'
         );
       });
+
+      it('handels function props', () => {
+        const myHandler = () => {
+          // clicked
+        };
+
+        expect(
+          render(<button onClick={myHandler}>Click me!</button>),
+          'when inspected to equal',
+          '<button onClick={...}>Click me!</button>'
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
I don't use the inspection of the props with a function value, so I would like to just dot them out. The diff will still show them (I think).