### PR TITLE
Make inspection less verbose

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,10 +82,14 @@ const unexpectedEnzyme = {
             return;
           }
 
-          startTag.sp().text(`${key}`);
-
           const value = props[key];
           const valueType = typeof value;
+          if (valueType === 'undefined') {
+            return;
+          }
+
+          startTag.sp().text(`${key}`);
+
           switch (valueType) {
             case 'string':
               startTag
@@ -108,7 +112,7 @@ const unexpectedEnzyme = {
             default:
               startTag
                 .text('={')
-                .appendInspected(value)
+                .append(inspect(value, 1))
                 .text('}');
           }
         });

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ const unexpectedEnzyme = {
       identify: false,
       inspect: function(reactWrapper, depth, output, inspect) {
         if (!reactWrapper.exists()) {
-          return output.jsKeyword('null');
+          return output.appendInspected(null);
         }
 
         if (reactWrapper.length > 1) {
@@ -73,8 +73,8 @@ const unexpectedEnzyme = {
         }
 
         const startTag = output.clone();
-        startTag.text('<');
-        startTag.jsKeyword(name);
+        startTag.prismPunctuation('<');
+        startTag.prismTag(name);
 
         const props = reactWrapper.props();
         Object.keys(props).forEach(key => {
@@ -93,27 +93,29 @@ const unexpectedEnzyme = {
           switch (valueType) {
             case 'string':
               startTag
-                .text('=')
-                .jsString('"')
-                .jsString(value)
-                .jsString('"');
+                .prismPunctuation('="')
+                .prismAttrValue(value)
+                .prismPunctuation('"');
+              break;
+            case 'function':
+              startTag
+                .prismPunctuation('={')
+                .text('...')
+                .prismPunctuation('}');
               break;
             case 'boolean':
               if (!value) {
                 startTag
-                  .text('={')
-                  .jsPrimitive(value)
-                  .text('}');
+                  .prismPunctuation('={')
+                  .appendInspected(value)
+                  .prismPunctuation('}');
               }
-              break;
-            case 'function':
-              startTag.text('={...}');
               break;
             default:
               startTag
-                .text('={')
+                .prismPunctuation('={')
                 .append(inspect(value, 1))
-                .text('}');
+                .prismPunctuation('}');
           }
         });
 
@@ -124,16 +126,16 @@ const unexpectedEnzyme = {
         }
 
         if (children.length === 0) {
-          startTag.text(' />');
+          startTag.prismPunctuation(' />');
           output.append(startTag);
         } else {
-          startTag.text('>');
+          startTag.prismPunctuation('>');
 
           const endTag = output
             .clone()
-            .text('</')
-            .jsKeyword(reactWrapper.name())
-            .text('>');
+            .prismPunctuation('</')
+            .prismTag(reactWrapper.name())
+            .prismPunctuation('>');
 
           const inspectedChildren = children.map(
             child =>

--- a/test/inspect.spec.js
+++ b/test/inspect.spec.js
@@ -12,11 +12,11 @@ describe('inspect', () => {
     });
 
     describe(`with ${type}`, () => {
-      it('handels an element without any children', () => {
+      it('handles an element without any children', () => {
         expect(render(<div />), 'when inspected to equal', '<div />');
       });
 
-      it('handels an element with a single text child', () => {
+      it('handles an element with a single text child', () => {
         expect(
           render(<div>single</div>),
           'when inspected to equal',
@@ -24,7 +24,7 @@ describe('inspect', () => {
         );
       });
 
-      it('handels multiple text childrens', () => {
+      it('handles multiple text childrens', () => {
         expect(
           render(
             <div>
@@ -38,7 +38,7 @@ describe('inspect', () => {
         );
       });
 
-      it('handels multiple text childrens mixed with elements', () => {
+      it('handles multiple text childrens mixed with elements', () => {
         expect(
           render(
             <div>
@@ -54,7 +54,7 @@ describe('inspect', () => {
         );
       });
 
-      it('handels function props', () => {
+      it('handles function props', () => {
         const myHandler = () => {
           // clicked
         };

--- a/test/inspect.spec.js
+++ b/test/inspect.spec.js
@@ -1,5 +1,6 @@
 import expect from './unexpected-enzyme';
 import React from 'react';
+import PropTypes from 'prop-types';
 import enzyme from 'enzyme';
 
 describe('inspect', () => {
@@ -64,6 +65,63 @@ describe('inspect', () => {
           '<button onClick={...}>Click me!</button>'
         );
       });
+
+      it('does not render undefined props', () => {
+        expect(
+          render(<div id="undefined" className={undefined} />),
+          'when inspected to equal',
+          '<div id="undefined" />'
+        );
+      });
     });
+  });
+
+  it('dot out deeply nested props', () => {
+    const ConfigProvider = () => <div />; // fake
+
+    expect(
+      enzyme.mount(
+        <ConfigProvider config={{ nested: { deeply: { nested: 'value' } } }}>
+          <div />
+        </ConfigProvider>
+      ),
+      'when inspected to equal',
+      [
+        '<ConfigProvider config={{ nested: ... }}>',
+        '  <div />',
+        '</ConfigProvider>'
+      ].join('\n')
+    );
+  });
+
+  it('does not dot out props containing react nodes', () => {
+    const Fullname = ({ firstName, lastName }) => (
+      <div>
+        <div>{firstName}</div>
+        <div>{lastName}</div>
+      </div>
+    );
+    Fullname.propTypes = {
+      firstName: PropTypes.node,
+      lastName: PropTypes.node
+    };
+
+    expect(
+      enzyme.mount(
+        <Fullname
+          firstName={<span>Sune</span>}
+          lastName={<span>Simonsen</span>}
+        />
+      ),
+      'when inspected to equal',
+      [
+        '<Fullname firstName={<span>Sune</span>} lastName={<span>Simonsen</span>}>',
+        '  <div>',
+        '    <div><span>Sune</span></div>',
+        '    <div><span>Simonsen</span></div>',
+        '  </div>',
+        '</Fullname>'
+      ].join('\n')
+    );
   });
 });


### PR DESCRIPTION
One of the problems I'm experiencing with unexpected-react is that to output gets really verbose, I would like us to try to hold back some details until we might need them.

You can always reveal the sections that has been dotted out by setting UNEXPECTED_DEPTH.